### PR TITLE
check for long values which can be used for model ids

### DIFF
--- a/armstrong/core/arm_access/tests/widgets.py
+++ b/armstrong/core/arm_access/tests/widgets.py
@@ -73,6 +73,19 @@ class AccessWidgetTestCase(ArmAccessTestCase):
         self.assertFalse(context['is_public'])
         self.assertEqual(2, len(context['assignments']))
 
+    def testContextWithLongId(self):
+        name = '%i' % random.randint(1000, 10000)
+        foo = Level.objects.create(name='foo')
+        bar = Level.objects.create(name='bar')
+        obj = AccessObject.objects.create()
+        obj.create(level=foo, start_date=datetime.datetime.now())
+        obj.create(level=bar, start_date=datetime.datetime.now())
+        context = self.widget.get_context(name, long(obj.id))
+        self.assertFalse(context['hidden'])
+        self.assertEqual(name, context['name'])
+        self.assertFalse(context['is_public'])
+        self.assertEqual(2, len(context['assignments']))
+
     def testContextWithNone(self):
         name = '%i' % random.randint(1000, 10000)
         context = self.widget.get_context(name, None)

--- a/armstrong/core/arm_access/widgets.py
+++ b/armstrong/core/arm_access/widgets.py
@@ -62,7 +62,7 @@ class AccessWidget(Widget):
             # if object.access is None
             assignments = EmptyAssignmentFormSet(prefix=prefix,
                     queryset=Assignment.objects.none())
-        elif type(value) == int:
+        elif type(value) in (int, long):
             # initial code path, we get the ID of the access object
             assignments = AssignmentFormSet(prefix=prefix,
                     queryset=Assignment.objects.filter(access_object=value))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "armstrong.core.arm_access",
-    "version": "1.0.3",
+    "version": "1.0.4.alpha.0",
     "description": "Code for having different access levels for content",
     "install_requires": [
         "Django==1.3.1"


### PR DESCRIPTION
sqlite only uses ints for model ids. When using MySQL id's are longs, so they get passed on through.
