### PR TITLE
InlineAssignmentForm would override user data

### DIFF
--- a/armstrong/core/arm_access/models.py
+++ b/armstrong/core/arm_access/models.py
@@ -108,7 +108,7 @@ class AccessMembership(models.Model):
     active = models.BooleanField(default=True)
 
     def __unicode__(self):
-        return "%s (%s)" % (self.user, self.access_level)
+        return "%s (%s)" % (self.user, self.level)
 
     @property
     def remaining(self):

--- a/armstrong/core/arm_access/tests/models.py
+++ b/armstrong/core/arm_access/tests/models.py
@@ -1,0 +1,17 @@
+from armstrong.dev.tests.utils.users import generate_random_user
+
+from ._utils import *
+from ..models import *
+from .arm_access_support.models import *
+
+
+class AccessModelsTestCase(ArmAccessTestCase):
+    def testAccessMembershipStr(self):
+        args = {}
+        args['user'] = generate_random_user()
+        args['level'] = Level(name="foo", is_protected=False)
+        args['start_date'] = datetime.datetime.now()
+        args['end_date'] = datetime.datetime.now()
+        self.assertEqual('%s (foo)' % (args['user']),
+                         str(AccessMembership(**args)))
+

--- a/armstrong/core/arm_access/tests/widgets.py
+++ b/armstrong/core/arm_access/tests/widgets.py
@@ -65,26 +65,30 @@ class AccessWidgetTestCase(ArmAccessTestCase):
         foo = Level.objects.create(name='foo')
         bar = Level.objects.create(name='bar')
         obj = AccessObject.objects.create()
-        obj.create(level=foo, start_date=datetime.datetime.now())
+        obj.create(level=foo, start_date=datetime.datetime(2011, 8, 12, 12, 50, 56))
         obj.create(level=bar, start_date=datetime.datetime.now())
         context = self.widget.get_context(name, obj.id)
         self.assertFalse(context['hidden'])
         self.assertEqual(name, context['name'])
         self.assertFalse(context['is_public'])
         self.assertEqual(2, len(context['assignments']))
+        self.assertEqual(datetime.datetime(2011, 8, 12, 12, 50, 56),
+                context['assignments'][0].initial['start_date'])
 
     def testContextWithLongId(self):
         name = '%i' % random.randint(1000, 10000)
         foo = Level.objects.create(name='foo')
         bar = Level.objects.create(name='bar')
         obj = AccessObject.objects.create()
-        obj.create(level=foo, start_date=datetime.datetime.now())
+        obj.create(level=foo, start_date=datetime.datetime(2011, 8, 12, 12, 50, 56))
         obj.create(level=bar, start_date=datetime.datetime.now())
         context = self.widget.get_context(name, long(obj.id))
         self.assertFalse(context['hidden'])
         self.assertEqual(name, context['name'])
         self.assertFalse(context['is_public'])
         self.assertEqual(2, len(context['assignments']))
+        self.assertEqual(datetime.datetime(2011, 8, 12, 12, 50, 56),
+                context['assignments'][0].initial['start_date'])
 
     def testContextWithIntId(self):
         name = '%i' % random.randint(1000, 10000)

--- a/armstrong/core/arm_access/widgets.py
+++ b/armstrong/core/arm_access/widgets.py
@@ -18,7 +18,8 @@ class InlineAssignmentForm(ModelForm):
         super(InlineAssignmentForm, self).__init__(*args, **kwargs)
         # necessary because SplitDateTimeWidget doesn't follow the spec and
         # call callables, instead it tries to unpack the value
-        self.initial['start_date'] = datetime.now()
+        if self.initial is not None and not 'start_date' in self.initial:
+            self.initial['start_date'] = datetime.now()
 
     class Meta:
         exclude = ('access_object', 'id')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "armstrong.core.arm_access",
-    "version": "1.0.4",
+    "version": "1.0.5.alpha.0",
     "description": "Code for having different access levels for content",
     "install_requires": [
         "Django==1.3.1"


### PR DESCRIPTION
The code path that pulls data from the database would overwrite the start date for an Assignment with datetime.datetime.now()
